### PR TITLE
Show upgrade pop-up when exporting to Excel

### DIFF
--- a/src/hooks/useSearchLimit.ts
+++ b/src/hooks/useSearchLimit.ts
@@ -28,12 +28,34 @@ export function useSearchLimit() {
     return true; // Always allow searches
   };
 
+  const checkSubscriptionStatus = async () => {
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        return false;
+      }
+      const { data, error } = await supabase
+        .from('subscriptions')
+        .select('status')
+        .eq('user_id', session.user.id)
+        .single();
+      if (error || !data) {
+        return false;
+      }
+      return data.status === 'active';
+    } catch (err) {
+      console.error('Error checking subscription status:', err);
+      return false;
+    }
+  };
+
   return {
     searchCount: 0,
     isLoading,
     error,
     incrementSearchCount,
     remainingSearches: Infinity,
-    hasSubscription: true
+    hasSubscription: true,
+    checkSubscriptionStatus
   };
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -25,7 +25,7 @@ import { searchTwitterProfiles } from '../api/searchTwitterProfiles';
 import { exportToExcel } from '../utils/exportToExcel';
 import { SearchFiltersState, Profile, SearchResponse } from '../types';
 import { supabase } from '../lib/supabase';
-import { useSearchLimit } from '../hooks/useSearchLimit';
+import { useSearchLimit, checkSubscriptionStatus } from '../hooks/useSearchLimit';
 
 const platformIcons = {
   linkedin: Linkedin,
@@ -111,6 +111,12 @@ export default function Dashboard() {
   };
 
   const handleExport = async () => {
+    const hasSubscription = await checkSubscriptionStatus();
+    if (!hasSubscription) {
+      setShowUpgradeModal(true);
+      return;
+    }
+
     setIsExporting(true);
     try {
       await exportToExcel(searchResponse?.items || [], filters);


### PR DESCRIPTION
Add upgrade pop-up when clicking "Export to Excel" button if user does not have a subscription.

* **`src/hooks/useSearchLimit.ts`**
  - Add `checkSubscriptionStatus` function to check user's subscription status.
  - Export `checkSubscriptionStatus` function.

* **`src/pages/Dashboard.tsx`**
  - Import `checkSubscriptionStatus` function from `useSearchLimit`.
  - Update `handleExport` function to check user's subscription status before proceeding with export process.
  - Show upgrade modal if user does not have a subscription when clicking "Export to Excel" button.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/WEBXELA/wx-lexp/pull/3?shareId=d58670b4-3f45-469f-bf19-76f6de31914c).